### PR TITLE
Enable compile downstream build everywhere

### DIFF
--- a/job-dsls/jobs/kie/main/compile_downstream_build.groovy
+++ b/job-dsls/jobs/kie/main/compile_downstream_build.groovy
@@ -128,12 +128,7 @@ for (repoConfig in REPO_CONFIGS) {
             pipelineTriggers {
                 triggers {
                     ghprbTrigger {
-                        // execute CDB for drools, droolsjbpm-knowledge and appformer by default
-                        if ((repo != "drools") && (repo != "droolsjbpm-knowledge") && (repo != "appformer")) {
-                            onlyTriggerPhrase(true)
-                        } else {
-                            onlyTriggerPhrase(false)
-                        }
+                        onlyTriggerPhrase(false)
                         gitHubAuthId("${ghAuthTokenId}")
                         adminlist("")
                         orgslist("${ghOrgUnit}")

--- a/job-dsls/jobs/kie/main/compile_downstream_build_7_x.groovy
+++ b/job-dsls/jobs/kie/main/compile_downstream_build_7_x.groovy
@@ -118,11 +118,7 @@ for (repoConfig in REPO_CONFIGS) {
                 triggers {
                     ghprbTrigger {
                         // execute CDB for drools, droolsjbpm-knowledge and appformer by default
-                        if ((repo != "drools") && (repo != "droolsjbpm-knowledge") && (repo != "appformer")) {
-                            onlyTriggerPhrase(true)
-                        } else {
-                            onlyTriggerPhrase(false)
-                        }
+                        onlyTriggerPhrase(false)
                         gitHubAuthId("${ghAuthTokenId}")
                         adminlist("")
                         orgslist("${ghOrgUnit}")


### PR DESCRIPTION
This should enable automatic start of **compile** downstream build (not full downstream built) for all 7.x repositories. I will leave the decision to enable this to others, however I think it should be beneficial. 
