### PR TITLE
[BXMSPROD-1929] Centralize composite github actions

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -1,0 +1,60 @@
+name: 'Pull Request Backporting'
+description: 'Creates a backporting pull request'
+
+inputs:
+  target-branch:
+    description: "The branch where the cherry-pick must be applied"
+    required: true
+  title:
+    description: "The cherry-pick pull request title"
+    default: "${{ github.event.pull_request.title }}"
+    required: false
+  body:
+    description: "The cherry-pick pull request body"
+    default: "${{ github.event.pull_request.body }}"
+    required: false
+  original-pr-url:
+    description: "Original pull request url"
+    default: "${{ github.event.pull_request.html_url }}"
+    required: false
+  original-pr-branch:
+    description: "Original pull request branch name"
+    default: "${{ github.event.pull_request.head.ref }}"
+    required: false
+  author:
+    description: "Author of the original pull request"
+    default: "${{ github.event.pull_request.user.login }}"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
+    default: "[]"
+    required: false
+
+runs: 
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Prepare reviewers
+      id: prepare-reviewers
+      shell: bash
+      run: |
+        echo "Additional reviewers retrieved below"
+        echo "${{ inputs.additional-reviewers }}"
+        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        echo "reviewers = ${reviewers}"
+        echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
+    - name: Perform cherry pick
+      id: cherry-pick
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
+      with:
+        branch: "${{ inputs.target-branch }}"
+        title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
+        body: "**Backport:** ${{ inputs.original-pr-url }}\r\n\r\n${{ inputs.body }}"
+        labels: |
+          cherry-pick :cherries:
+        inherit_labels: false
+        cherry-pick-branch: "${{ inputs.target-branch }}_${{ inputs.original-pr-branch }}"
+        reviewers: ${{ env.BACKPORT_REVIEWERS }}

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -25,10 +25,21 @@ inputs:
     description: "Author of the original pull request"
     default: "${{ github.event.pull_request.user.login }}"
     required: false
-  additional-reviewers:
-    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
-    default: "[]"
+  include-merge-as-reviewer:
+    description: "Whether include or not who merged the pull request as reviewer of the backported one"
+    default: "true"
     required: false
+  include-requested-reviewers:
+    description: "Whether include or not original requested reviewers"
+    default: "true"
+    required: false
+  custom-reviewers:
+    description: "Comma separated list of additional reviewers to be added in backported pull request"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, default is toJSON(github.event.pull_request.requested_reviewers)"
+    required: false
+    deprecationMessage: "[IGNORED] The previous default is managed by `include-requested-reviewers`. If you want to add more custom reviewers use `custom-reviewers` input instead"
 
 runs: 
   using: 'composite'
@@ -37,18 +48,41 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Setup default values
+      shell: bash
+      env:
+        REQUESTED_REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+        MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+        CUSTOM_REVIEWERS: ""
+      run: |
+        # -- Additional Reviewers --
+        # trick to save multiline string as env variable
+        echo "REQUESTED_REVIEWERS<<EOF" >> $GITHUB_ENV
+        input_include_requested_revs=${{ inputs.include-requested-reviewers }}
+        [[ "$input_include_requested_revs" == "true" ]] && echo "$REQUESTED_REVIEWERS" >> $GITHUB_ENV || echo "[]" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+        # -- Custom Reviewers --
+        input_custom_revs=${{ inputs.custom-reviewers }}
+        [[ ! -z "$input_custom_revs" ]] \
+          && echo "CUSTOM_REVIEWERS=$(echo "[\"${input_custom_revs/,/\",\"}\"]")" >> $GITHUB_ENV \
+          || echo "CUSTOM_REVIEWERS=[]" >> $GITHUB_ENV
+        # -- Merged By Reviewer --
+        input_include_merge=${{ inputs.include-merge-as-reviewer }}
+        [[ "$input_include_merge" == "true" ]] && echo "MERGED_BY=$MERGED_BY" >> $GITHUB_ENV || echo "MERGED_BY=" >> $GITHUB_ENV
     - name: Prepare reviewers
       id: prepare-reviewers
       shell: bash
       run: |
-        echo "Additional reviewers retrieved below"
-        echo "${{ inputs.additional-reviewers }}"
-        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        env
+        # starts from request reviewers or empty array
+        reviewers="$(echo ${REQUESTED_REVIEWERS:-[]} | jq -c 'map(.login)' | jq -cr '[. |= . + ["${{ inputs.author }}", "${{ env.MERGED_BY }}"] | .[] | select(length > 0)] | unique')"
+        # add custom reviewers, if any
+        reviewers="$(jq -cr --argjson arr1 "$reviewers" --argjson arr2 "${CUSTOM_REVIEWERS:-[]}" -n '$arr1 + $arr2 | unique | join(",")')"
         echo "reviewers = ${reviewers}"
         echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
     - name: Perform cherry pick
       id: cherry-pick
-      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"

--- a/.ci/actions/build-chain/action.yml
+++ b/.ci/actions/build-chain/action.yml
@@ -1,0 +1,44 @@
+name: 'Build Chain'
+description: 'Executes build-chain tool'
+inputs:
+  github-token:
+    description: "the github token"
+    required: true
+  definition-file:
+    description: 'The `definition-file` input for the build-chain'
+    required: true
+  flow-type:
+    description: "the flow to execute, it can be 'pull-request', 'full-downstream', 'single' or 'branch'"
+    default: "pull-request"
+    required: false
+  starting-project:
+    description: "the project to start flow from. By default is the project triggering the job"
+    required: false
+  logger-level:
+    description: "the log level. 'info' (default) | 'trace' | 'debug'"
+    default: "info"
+    required: false
+  annotations-prefix:
+    description: "The prefix for the annotations title"
+    default: ''
+    required: false
+  additional-flags:
+    description: "The chance to define additional flags for the execution, as it is done on the CLI side. Just semicolon (;) separated, like '--skipParallelCheckout;--skipExecution;-cct (mvn .*)||$1 -s settings.xml'"
+    required: false
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build Chain Tool Execution
+      id: build-chain
+      uses: kiegroup/github-action-build-chain@v2.6.25
+      with:
+        definition-file: ${{ inputs.definition-file }}
+        flow-type: ${{ inputs.flow-type }}
+        starting-project: ${{ inputs.starting-project }}
+        logger-level: ${{ inputs.logger-level }}
+        annotations-prefix: ${{ inputs.annotations-prefix }}
+        additional-flags: ${{ inputs.additional-flags }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.ci/actions/long-paths/action.yml
+++ b/.ci/actions/long-paths/action.yml
@@ -1,0 +1,9 @@
+name: 'Support long paths'
+description: 'Sets up the environment to support long paths'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Support long paths
+      run: git config --system core.longpaths true
+      shell: bash

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -1,0 +1,117 @@
+name: 'Java + Maven configuration'
+description: 'Java and Maven version setup'
+inputs:
+  java-version:
+    description: "the java version"
+    default: "11"
+    required: false
+  maven-version:
+    description: "the maven version"
+    default: "3.8.6"
+    required: false
+  cache-key-prefix:
+    description: "the cache key"
+    required: false
+  allow-snapshots:
+    description: "Whether the download of snapshots should be allowed"
+    required: false
+    default: "false"
+  setup-maven-settings:
+    description: "Whether perform the maven settings setup"
+    required: false
+    default: "true"
+  debug:
+    description: "Activate debug display"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Jdk
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java-version }}
+        check-latest: true
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.2
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path:  ~/.m2
+        key: ${{ inputs.cache-key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys:  ${{ inputs.cache-key-prefix }}-m2
+    - name: Setup Maven Settings
+      if: ${{ inputs.setup-maven-settings == 'true' }}
+      uses: whelk-io/maven-settings-xml-action@v21
+      with:
+        repositories: >
+          [
+            {
+              "id": "jboss-public-repository-group",
+              "name": "JBoss Public Repository Group",
+              "url": "https://repository.jboss.org/nexus/content/groups/public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            },
+            {
+              "id": "kogito-staging-repository-group",
+              "name": "Kogito Staging Repositories",
+              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            }
+          ]
+        plugin_repositories: >
+          [
+            {
+              "id": "jboss-public-repository-group",
+              "name": "JBoss Public Repository Group",
+              "url": "https://repository.jboss.org/nexus/content/groups/public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            },
+            {
+              "id": "kogito-staging-repository-group",
+              "name": "Kogito Staging Repositories",
+              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            }
+          ]
+        plugin_groups: >
+          [
+            "org.zanata"
+          ]
+    - name: Debug settings.xml
+      if: ${{ inputs.debug }}
+      shell: bash
+      run: |
+        cat ~/.m2/settings.xml

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -1,0 +1,44 @@
+name: 'OS Preparation'
+description: 'Prepares the Operating Systems array'
+
+inputs:
+  repository:
+    description: "The repository containing the matrix-os.json os configuration"
+    required: true
+  branch:
+    description: "The repository branch from which the matrix configuration must be taken"
+    required: false
+    default: "main"
+
+outputs:
+  operating-systems:
+    description: Configured job operating systems
+    value: ${{ steps.set-os.outputs.operating_systems }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check out configs repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.branch }}
+        path: matrix_preparation
+    - id: set-os
+      env:
+        repo_name: ${{ github.event.repository.name }}
+        event: ${{ github.event_name }}
+        label_name: ${{ github.event.label.name }}
+        config_file: matrix_preparation/.github/matrix-os.json
+      shell: bash
+      run: |
+        os=$(jq --arg config_file "$config_file" --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' $GITHUB_WORKSPACE/$config_file | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
+        if [ -z "$os" ]; then 
+          echo "No configuration found for [repo=$repo_name, event=$event, value=$label_name] at $GITHUB_WORKSPACE/$config_file"
+          exit 1
+        else 
+          echo "operating_systems=$(echo $os)" >> $GITHUB_OUTPUT
+        fi
+    - name: Printing configured operating systems
+      shell: bash
+      run: echo "Configured os array ${{ steps.set-os.outputs.operating_systems }}"

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -27,7 +27,6 @@ runs:
         filtered_labels="$(echo ${{ inputs.labels }} | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
         echo "filtered_labels = ${filtered_labels}"
         echo "FILTERED_LABELS=${filtered_labels}" >> $GITHUB_ENV
-
     - name: Extract targets
       id: extract-targets
       shell: bash

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -1,0 +1,40 @@
+name: 'Parse Labels'
+description: 'Extract target branches or refs from labels'
+
+inputs:
+  labels:
+    description: "List of label objects to be parsed, e.g., github.event.pull_request.labels"
+    required: true
+  label-prefix:
+    description: "Extract targets from labels matching this provided prefix"
+    default: "backport-"
+    required: false
+
+outputs:
+  targets:
+    description: "Extracted targets"
+    value: ${{ steps.extract-targets.outputs.targets }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch labels
+      id: fetch-labels
+      shell: bash
+      run: |
+        echo "Labels retrieved below"
+        echo "${{ inputs.labels }}"
+        filtered_labels="$(echo ${{ inputs.labels }} | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
+        echo "filtered_labels = ${filtered_labels}"
+        echo "FILTERED_LABELS=${filtered_labels}" >> $GITHUB_ENV
+
+    - name: Extract targets
+      id: extract-targets
+      shell: bash
+      run: |
+        targets="$(echo $FILTERED_LABELS | jq -c '[.[] | .name | sub("${{ inputs.label-prefix }}"; "")]')"
+        echo "targets=$(echo $targets)" >> $GITHUB_OUTPUT
+    
+    - name: Printing extracted targets
+      shell: bash
+      run: echo "Extracted target branches ${{ steps.extract-targets.outputs.targets }}"

--- a/.ci/actions/surefire-report/action.yml
+++ b/.ci/actions/surefire-report/action.yml
@@ -1,0 +1,21 @@
+name: 'Surefire Report'
+description: 'Generates a test report'
+inputs:
+  report_paths:
+    description: "Glob expression to surefire or failsafe report paths."
+    required: false
+    default: "**/surefire-reports/TEST-*.xml"
+
+runs:
+  using: "composite"
+  steps: 
+    - name: Check Surefire Report
+      uses: ScaCap/action-surefire-report@v1.0.13
+      with:
+        fail_on_test_failures: true
+        fail_if_no_tests: false
+        skip_publishing: true
+        report_paths: ${{ inputs.report_paths }}
+      env:
+        # https://github.com/ScaCap/action-surefire-report/issues/17
+        NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.ci/actions/ubuntu-disk-space/action.yml
+++ b/.ci/actions/ubuntu-disk-space/action.yml
@@ -1,0 +1,23 @@
+name: 'Disk Space'
+description: 'Cleans up the disk space and reports about the available disk space'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Disk space report before modification
+      shell: bash
+      run: |
+        echo "Available storage:"
+        df -h
+    # Inspired to maximize-build-space action https://github.com/easimon/maximize-build-space
+    - name: Free disk space (remove dotnet, android and haskell)
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+    - name: Disk space report after modification
+      shell: bash
+      run: |
+        echo "Available storage:"
+        df -h

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,40 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/kie-ci/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    steps:
+      - name: Backporting
+        uses: kiegroup/kie-ci/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}


### PR DESCRIPTION
**Thank you for submitting this pull request**


**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1929

**referenced Pull Requests**: 


Centralize composite GitHub actions here, merging those from droolsjbpm-build-bootstrap and kogito-pipelines.

Differences from the original ones:

* **build-chain**:
  * removed default `definition-file` as it depends on the final project structure, there is no default - this must be provided by any workflow using this action
* **maven**:
  * made `Setup Maven Settings` optional since it is not needed in droolsjbpm-build-boostrap related projects, they will have to explicitly set `setup-maven-settings` to "false".
* **dsl-tests**:
  * added new input `seed-repository` which defaults to `kiegroup/kogito-pipelines` but can be overridden to make the action much more generic. 


<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
