### PR TITLE
[BXMSPROD-1960] RHBOP: split quarkus core and platform version

### DIFF
--- a/job-dsls/jobs/prod/prod_rhbop_trigger_umb_message.groovy
+++ b/job-dsls/jobs/prod/prod_rhbop_trigger_umb_message.groovy
@@ -13,7 +13,8 @@ pipelineJob("${folderPath}/rhbop-trigger-umb-message") {
     parameters {
         stringParam('PRODUCT_ID', '', 'The product ID. This parameter is optional and in case it is not defined, the default OSL product ID is used.')
         stringParam('MILESTONE', '', 'The release milestone, i.e. 8.29.0.CR1. This parameter is optional and in case it is not defined, the latest available milestone is used.')
-        stringParam('QUARKUS_VERSION', '2.7.6.Final-redhat-00006', 'The productized version of Quarkus used for building Red Hat build of OptaPlanner currect milestone.')
+        stringParam('QUARKUS_VERSION', '2.13.5.Final-redhat-00003', 'The productized version of Quarkus core used for building Red Hat build of OptaPlanner currect milestone.')
+        stringParam('QUARKUS_PLATFORM_VERSION', '2.13.5.SP1-redhat-00002', 'The productized version of Quarkus platform used for building Red Hat build of OptaPlanner currect milestone.')
         stringParam("PNC_API_URL", "\${ORCH_PSI_URL}/pnc-rest/v2", "PNC Rest API endpoint. See: \${DOCS_ENGINEERING_URL}/display/JP/User%27s+guide")
         stringParam("INDY_URL", "\${INDY_PNC_URL}", "Indy PNC builds repository")
     }

--- a/job-dsls/src/main/resources/job-scripts/prod_rhbop_trigger_umb_message.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_rhbop_trigger_umb_message.jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                 println "[INFO] PNC_API_URL: ${PNC_API_URL}"
                 println "[INFO] INDY_URL: ${INDY_URL}"
                 println "[INFO] QUARKUS_VERSION: ${QUARKUS_VERSION}"
+                println "[INFO] QUARKUS_PLATFORM_VERSION: ${QUARKUS_PLATFORM_VERSION}"
                 println "[INFO] PROJECTS: ${projects}"
                 println "[INFO] PRODUCT_ID: ${productId}"
             }
@@ -79,7 +80,7 @@ def getMessageBody(milestone, projectsAndVersions) {
     return """
 {
     "built_projects": ["drools","optaplanner","optaplanner-quickstarts","optaweb-vehicle-routing","jboss-integration/rhbop-optaplanner"],
-    "version": {"rhbop":"${milestone}","optaplanner":"${projectsAndVersions["kiegroup/optaplanner"]}","drools":"${projectsAndVersions["kiegroup/drools"]}","platform.quarkus.bom":"${QUARKUS_VERSION}"},
+    "version": {"rhbop":"${milestone}","optaplanner":"${projectsAndVersions["kiegroup/optaplanner"]}","drools":"${projectsAndVersions["kiegroup/drools"]}","quarkus.bom":"${QUARKUS_VERSION}","platform.quarkus.bom":"${QUARKUS_PLATFORM_VERSION}"},
     "maven_repository_file_url": "${env.STAGING_SERVER_URL}rhbop/rhbop-${milestone}/rhbop-${productVersion}-optaplanner-maven-repository.zip",
     "offliner_file_url": "${env.STAGING_SERVER_URL}rhbop/rhbop-${milestone}/rhbop-${productVersion}-optaplanner-offliner.zip",
     "archives": "${INDY_URL}",


### PR DESCRIPTION
**Thank you for submitting this pull request**

Since Quarkus 2.13.x, core and platform artifacts could be different each other - for this reason we split versions in:
- `platform.quarkus.bom`
- `quarkus.bom` 

**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1960

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
