### PR TITLE
[BXMSPROD-1963] Removed use of ownership plugin

### DIFF
--- a/job-dsls/build.gradle
+++ b/job-dsls/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     // should be 1.5.16 but 1.5.16 is missing in the repo
     // testPlugins 'com.redhat.jenkins.plugins:redhat-ci-plugin:1.5.10'
     testPlugins 'com.sonyericsson.hudson.plugins.rebuild:rebuild:1.34'
-    testPlugins 'com.synopsys.jenkinsci:ownership:0.13.0'
     testPlugins 'io.jenkins.plugins:warnings-ng:9.0.1'
     testPlugins 'org.jenkins-ci.main:maven-plugin:3.19'
     testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:6.16'

--- a/job-dsls/jobs/kie/branch/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/branch/deploy_jobs.groovy
@@ -170,13 +170,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("almorale", "anstephe")
-            }
-        }
-
         label(get("label"))
 
         jdk(get("javadk"))

--- a/job-dsls/jobs/kie/branch/deploy_jobs_7_x.groovy
+++ b/job-dsls/jobs/kie/branch/deploy_jobs_7_x.groovy
@@ -108,13 +108,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("almorale", "anstephe")
-            }
-        }
-
         jdk(get("javadk"))
 
         label(get("label"))

--- a/job-dsls/jobs/kie/branch/errai_jdk8_pr.groovy
+++ b/job-dsls/jobs/kie/branch/errai_jdk8_pr.groovy
@@ -64,13 +64,6 @@ job(jobName) {
     }
     concurrentBuild()
 
-    properties {
-        ownership {
-            primaryOwnerId("mbiarnes")
-            coOwnerIds("mnovotny")
-        }
-    }
-
     jdk(javadk)
 
     label(labelName)

--- a/job-dsls/jobs/kie/branch/errai_pr.groovy
+++ b/job-dsls/jobs/kie/branch/errai_pr.groovy
@@ -64,13 +64,6 @@ job(jobName) {
     }
     concurrentBuild()
 
-    properties {
-        ownership {
-            primaryOwnerId("mbiarnes")
-            coOwnerIds("mnovotny")
-        }
-    }
-
     jdk(javadk)
 
     label(labelName)

--- a/job-dsls/jobs/kie/branch/kie_jenkinsScripts_PR.groovy
+++ b/job-dsls/jobs/kie/branch/kie_jenkinsScripts_PR.groovy
@@ -82,13 +82,6 @@ job(jobName) {
 
     concurrentBuild()
 
-    properties {
-        ownership {
-            primaryOwnerId("mbiarnes")
-            coOwnerIds("mbiarnes")
-        }
-    }
-
     triggers {
         githubPullRequest {
             useGitHubHooks()

--- a/job-dsls/jobs/kie/branch/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/kie/branch/sonarcloud_daily.groovy
@@ -94,13 +94,6 @@ for (repoConfig in REPO_CONFIGS) {
         }
         concurrentBuild()
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("mbiarnes")
-            }
-        }
-
         jdk("kie-jdk11")
 
         label(get("label"))

--- a/job-dsls/jobs/kie/branch/springboot_pr_job.groovy
+++ b/job-dsls/jobs/kie/branch/springboot_pr_job.groovy
@@ -91,13 +91,6 @@ job(jobName) {
     }
     concurrentBuild()
 
-    properties {
-        ownership {
-            primaryOwnerId("mbiarnes")
-            coOwnerIds("mbiarnes")
-        }
-    }
-
     jdk("kie-jdk1.8")
 
     label(get("label"))

--- a/job-dsls/jobs/kie/branch/turtleTests.groovy
+++ b/job-dsls/jobs/kie/branch/turtleTests.groovy
@@ -70,13 +70,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("almorale", "anstephe")
-            }
-        }
-
         jdk(get("javadk"))
 
         label(get("label"))

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/BasicJob.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/BasicJob.groovy
@@ -60,20 +60,6 @@ class BasicJob {
                 artifactNumToKeep(2)
             }
 
-            // Adds custom properties to the job.
-            properties {
-
-                // Allows to configure job ownership.
-                ownership {
-
-                    // Sets the name of the primary owner of the job.
-                    primaryOwnerId("mbiarnes")
-
-                    // Adds additional users, who have ownership privileges.
-                    coOwnerIds("anstephe", "mnovotny", "almorale")
-                }
-            }
-
             // Adds post-build actions to the job.
             publishers {
 


### PR DESCRIPTION
In any DSL groovy script JOB_OWNER_EMAIL or JOB_COOWNERS_EMAIL are used

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-1963](https://issues.redhat.com/browse/BXMSPROD-1963)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
