### PR TITLE
removed ownership plugin dependencies

### DIFF
--- a/job-dsls/build.gradle
+++ b/job-dsls/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     // should be 1.5.16 but 1.5.16 is missing in the repo
     // testPlugins 'com.redhat.jenkins.plugins:redhat-ci-plugin:1.5.10'
     testPlugins 'com.sonyericsson.hudson.plugins.rebuild:rebuild:1.34'
-    testPlugins 'com.synopsys.jenkinsci:ownership:0.13.0'
     testPlugins 'io.jenkins.plugins:warnings-ng:9.0.1'
     testPlugins 'org.jenkins-ci.main:maven-plugin:3.19'
     testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:6.16'

--- a/job-dsls/jobs/kie/branch/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/branch/deploy_jobs.groovy
@@ -186,13 +186,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("almorale", "anstephe")
-            }
-        }
-
         label(get("label"))
 
         jdk(get("javadk"))

--- a/job-dsls/jobs/kie/branch/kie_jenkinsScripts_PR.groovy
+++ b/job-dsls/jobs/kie/branch/kie_jenkinsScripts_PR.groovy
@@ -82,13 +82,6 @@ job(jobName) {
 
     concurrentBuild()
 
-    properties {
-        ownership {
-            primaryOwnerId("mbiarnes")
-            coOwnerIds("mbiarnes")
-        }
-    }
-
     triggers {
         githubPullRequest {
             useGitHubHooks()

--- a/job-dsls/jobs/kie/branch/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/kie/branch/sonarcloud_daily.groovy
@@ -93,13 +93,6 @@ for (repoConfig in REPO_CONFIGS) {
         }
         concurrentBuild()
 
-        properties {
-            ownership {
-                primaryOwnerId("mbiarnes")
-                coOwnerIds("mbiarnes")
-            }
-        }
-
         jdk("kie-jdk11")
 
         label(get("label"))

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/BasicJob.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/BasicJob.groovy
@@ -54,24 +54,10 @@ class BasicJob {
             logRotator {
 
                 // If specified, only up to this number of build records are kept.
-                numToKeep(25)
+                numToKeep(20)
 
                 // If specified, only up to this number of builds have their artifacts retained.
                 artifactNumToKeep(2)
-            }
-
-            // Adds custom properties to the job.
-            properties {
-
-                // Allows to configure job ownership.
-                ownership {
-
-                    // Sets the name of the primary owner of the job.
-                    primaryOwnerId("mbiarnes")
-
-                    // Adds additional users, who have ownership privileges.
-                    coOwnerIds("anstephe", "mnovotny", "almorale")
-                }
             }
 
             // Adds post-build actions to the job.


### PR DESCRIPTION
removed leftovers of ownership plugin on branch 7.67.x.
On `eng-jenkins` we don't have/use this plugin anymore - this is the reason why the seed job for 7.67.x fails.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-ci/pull/1445
* https://github.com/kiegroup/kie-ci/pull/1446

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
