### PR TITLE
wait for caching artifacts when uploading to Nexus

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmContainerTestMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmContainerTestMatrix.groovy
@@ -36,7 +36,7 @@ class JbpmContainerTestMatrix {
             def jbpmContainerTest = '''#!/bin/bash -e
                                             \n echo "KIE version $kieVersion"
                                             \n echo "Nexus URL:  $nexusUrl"
-                                            \n wget -q $nexusUrl/org/jbpm/jbpm/$kieVersion/jbpm-$kieVersion-project-sources.tar.gz -O sources.tar.gz
+                                            \n wget --retry-connrefused --waitretry=1 --read-timeout=300 $nexusUrl/org/jbpm/jbpm/$kieVersion/jbpm-$kieVersion-project-sources.tar.gz -O sources.tar.gz
                                             \n tar xzf sources.tar.gz
                                             \n rm sources.tar.gz
                                             \n mv jbpm-$kieVersion/* .

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmTestCoverageMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmTestCoverageMatrix.groovy
@@ -36,7 +36,7 @@ class JbpmTestCoverageMatrix {
             def jbpmTestCoverage = '''#!/bin/bash -e
                                             \n echo "KIE version $kieVersion"
                                             \n echo "Nexus URL:  $nexusUrl"
-                                            \n wget -q $nexusUrl/org/jbpm/jbpm/$kieVersion/jbpm-$kieVersion-project-sources.tar.gz -O sources.tar.gz
+                                            \n wget --retry-connrefused --waitretry=1 --read-timeout=300 $nexusUrl/org/jbpm/jbpm/$kieVersion/jbpm-$kieVersion-project-sources.tar.gz -O sources.tar.gz
                                             \n tar xzf sources.tar.gz
                                             \n rm sources.tar.gz
                                             \n mv jbpm-$kieVersion/* .

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieServerMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieServerMatrix.groovy
@@ -38,7 +38,7 @@ class KieServerMatrix {
                                         \n echo "KIE version $kieVersion"
                                         \n echo "Nexus URL:  $nexusUrl"
                                         \n # wget the tar.gz sources
-                                        \n wget -q $nexusUrl/org/drools/droolsjbpm-integration/$kieVersion/droolsjbpm-integration-$kieVersion-project-sources.tar.gz -O sources.tar.gz
+                                        \n wget --retry-connrefused --waitretry=1 --read-timeout=300 $nexusUrl/org/drools/droolsjbpm-integration/$kieVersion/droolsjbpm-integration-$kieVersion-project-sources.tar.gz -O sources.tar.gz
                                         \n tar xzf sources.tar.gz
                                         \n rm sources.tar.gz
                                         \n mv droolsjbpm-integration-$kieVersion/* .

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieWbTestMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieWbTestMatrix.groovy
@@ -37,13 +37,13 @@ class KieWbTestMatrix {
                                    \n echo "KIE version $kieVersion"
                                    \n echo "Nexus URL:  $nexusUrl"
                                    \n echo "KIE version $kieVersion - kie-wb-distributions"
-                                   \n wget -q $nexusUrl/org/kie/kie-wb-distributions/$kieVersion/kie-wb-distributions-$kieVersion-project-sources.tar.gz -O sources.tar.gz
+                                   \n wget --retry-connrefused --waitretry=1 --read-timeout=300 $nexusUrl/org/kie/kie-wb-distributions/$kieVersion/kie-wb-distributions-$kieVersion-project-sources.tar.gz -O sources.tar.gz
                                    \n tar xzf sources.tar.gz
                                    \n rm sources.tar.gz
                                    \n mv kie-wb-distributions-$kieVersion/* .
                                    \n rm -rf kie-wb-distributions-$kieVersion
                                    \n echo "KIE version $kieVersion - kie-wb-common"
-                                   \n wget -q $nexusUrl/org/kie/workbench/kie-wb-common/$kieVersion/kie-wb-common-$kieVersion-project-sources.tar.gz -O sources.tar.gz
+                                   \n wget --retry-connrefused --waitretry=1 --read-timeout=300 $nexusUrl/org/kie/workbench/kie-wb-common/$kieVersion/kie-wb-common-$kieVersion-project-sources.tar.gz -O sources.tar.gz
                                    \n tar xzf sources.tar.gz
                                    \n rm sources.tar.gz
                                    \n mv kie-wb-common-$kieVersion/* .


### PR DESCRIPTION
The additional tests for daily builds

- JbpmContainerTestMatrix
- JbpmTestCoverageMatrix
- KieServerMatrix
- KieWbTestMatrix

are executed as first for main && jdk11.
The first time when trying to download via **wget** the artifacts they are not cached.
All daily builds after this find the artifacts because they have been cached. The new **wget** parameters  will try it several times with hopefully enough time in between to resolve this.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
