### PR TITLE
Drop optaplanner 7.x branch from deploy jobs

### DIFF
--- a/job-dsls/jobs/kie/branch/deploy_jobs_7_x.groovy
+++ b/job-dsls/jobs/kie/branch/deploy_jobs_7_x.groovy
@@ -35,19 +35,10 @@ def final REPO_CONFIGS = [
                 downstreamRepos        : ["drools-7.x"]
         ],
         "drools"                    : [
-                downstreamRepos        : ["optaplanner-7.x", "/KIE/main/deployedRepo/jbpm"],
+                downstreamRepos        : [],
                 artifactsToArchive     : ["**/target/testStatusListener*"]
         ],
-        "kie-jpmml-integration"     : [],
-        "optaplanner"               : [
-                downstreamRepos     : ["/KIE/main/deployedRepo/droolsjbpm-integration", "optaweb-employee-rostering-7.x"],
-                mvnGoals: "-e -fae -B clean deploy com.github.spotbugs:spotbugs-maven-plugin:spotbugs",
-                mvnProps: [
-                        "full"                     : "true",
-                        "integration-tests"        : "true",
-                        "maven.test.failure.ignore": "true"
-                ]
-        ]
+        "kie-jpmml-integration"     : []       
 ]
 
 for (repoConfig in REPO_CONFIGS) {


### PR DESCRIPTION
i noticed that the job on 7.x is failing with deploying and as it is setup to fixed version it doesn't make sense to deploy anything.
I removed it from downstream repositories to deploy
it will not generate this job path anymore /KIE/job/7.x/job/deployedRep/job/optaplanner-7.x/

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
