### PR TITLE
SRVLOGIC-282: Move main-sync CI to kie-ci repository

### DIFF
--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -27,7 +27,8 @@ inputs:
     default: false
 
 runs:
-  if: github.repository_owner == 'kiegroup'
+  # TODO: uncomment this
+  # if: github.repository_owner == 'kiegroup'
   using: 'composite'
   steps:
     - name: Generate PR ID
@@ -84,7 +85,7 @@ runs:
 
     - name: Push changes
       if: steps.check_changes.outputs.is_changed == 'true'
-      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}{{ if inputs.dry_run == 'true' }} --dry-run{{ endif }}
+      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}{{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -85,7 +85,9 @@ runs:
 
     - name: Push changes
       if: steps.check_changes.outputs.is_changed == 'true'
-      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
+      run: |
+        set -x
+        git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -87,7 +87,7 @@ runs:
       if: steps.check_changes.outputs.is_changed == 'true'
       run: |
         set -x
-        git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
+        git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ inputs.dry_run == 'true' && ' --dry-run' || '' }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -20,6 +20,11 @@ inputs:
   main_sync_workflow_pr_reviewers:
     description: 'Reviewers for the PR'
     required: false
+    default: ''
+  dry_run:
+    description: 'Whether to perform a dry run (skip push and create PR steps)'
+    required: false
+    default: false
 
 runs:
   using: 'composite'
@@ -77,11 +82,11 @@ runs:
         fi
 
     - name: Push changes
-      if: steps.check_changes.outputs.is_changed == 'true'
+      if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'
       run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}
 
     - name: Create the PR
-      if: steps.check_changes.outputs.is_changed == 'true'
+      if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'
       run: |
         set -x
         runUrl="${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -1,0 +1,101 @@
+name: 'Sync main branch'
+description: 'Create a PR to sync main branch with main-apache excluding '
+
+inputs:
+  username:
+    description: 'Username for git'
+    required: false
+    default: kie-ci
+  useremail:
+    description: 'User email for git'
+    required: false
+    default: kie-ci0@redhat.com
+  github_token:
+    description: 'GitHub token for authentication'
+    required: true
+  main_sync_workflow_exclude_paths:
+    description: 'Paths to be excluded during merge'
+    required: false
+    default: .ci .github
+  main_sync_workflow_pr_reviewers:
+    description: 'Reviewers for the PR'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Generate PR ID
+      id: generate_pr_id
+      run: echo "pr_id=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        # By default, checkout@v4 fetches only a single commit unless you specify "fetch-depth: 0". Without this "git merge" throwns an "unrelated histories".
+        fetch-depth: '0'
+
+    - name: Setup git environment
+      run: |
+        git config --global user.name "${{ inputs.username }}"
+        git config --global user.email "${{ inputs.useremail }}"
+
+    - name: Fetch all
+      run: git fetch --all
+
+    - name: Checkout main branch
+      run: git checkout main
+
+    - name: Create the PR branch
+      run: git checkout -b sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}
+
+    - name: Merge main-apache branch excluding white-listed paths
+      id: merge
+      run: |
+        set -x
+        git merge --no-commit origin/main-apache || true
+        if [ -n "${{ inputs.main_sync_workflow_exclude_paths }}" ]; then
+          git reset origin/main "${{ inputs.main_sync_workflow_exclude_paths }}"
+        fi
+        if git diff --cached --quiet; then
+          echo "No changes staged for commit."
+        else
+          git commit -m "Merge main-apache and exclude white-listed changes from the merge"
+        fi
+        echo "excluded_files=$(git ls-files -mo | sed -z 's/\n/<br \/>/g')" >> $GITHUB_OUTPUT
+
+    - name: Check for changes
+      id: check_changes
+      run: |
+        set -x
+        if git diff --quiet origin/main; then
+          echo "No changes detected."
+          echo "is_changed=false" >> $GITHUB_OUTPUT
+        else
+          echo "Changes detected."
+          echo "is_changed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Push changes
+      if: steps.check_changes.outputs.is_changed == 'true'
+      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}
+
+    - name: Create the PR
+      if: steps.check_changes.outputs.is_changed == 'true'
+      run: |
+        set -x
+        runUrl="${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        if [[ -n "${{ steps.merge.outputs.excluded_files }}" ]]; then
+          excludedFiles="${{ steps.merge.outputs.excluded_files }}"
+        else
+          excludedFiles="No files have been excluded<br />"
+        fi
+        prTitle="Automatic PR: Sync main with main-apache (${{steps.generate_pr_id.outputs.pr_id}})"
+        prBody="This pull request has been created by a GitHub workflow to synchronize the main branch with main-apache branch.<br /><br />\
+            <b>:warning:Important:warning:</b><br />Please don't merge using squash, not to lose the git history.<br /><br />\
+            <b>Excluded files:</b><br />${excludedFiles}<br />\
+            [View Action](${runUrl})"
+        if [[ -n "${{ inputs.main_sync_workflow_pr_reviewers }}" ]]; then
+          reviewersOption="--reviewer ${{inputs.main_sync_workflow_pr_reviewers}}"
+        fi
+        gh pr create --title "${prTitle}" --body "${prBody}" --base main $reviewersOption

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -13,7 +13,7 @@ inputs:
   main_sync_workflow_exclude_paths:
     description: 'Paths to be excluded during merge'
     required: false
-    default: .ci .github
+    default: .ci .github .asf.yaml
   main_sync_workflow_pr_reviewers:
     description: 'Reviewers for the PR'
     required: false

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -24,8 +24,7 @@ inputs:
     default: false
 
 runs:
-  # TODO: uncomment this
-  # if: github.repository_owner == 'kiegroup'
+  if: github.repository_owner == 'kiegroup'
   using: 'composite'
   steps:
     - name: Generate PR ID

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -61,7 +61,7 @@ runs:
         set -x
         git merge --no-commit origin/main-apache || true
         if [ -n "${{ inputs.main_sync_workflow_exclude_paths }}" ]; then
-          git reset origin/main "${{ inputs.main_sync_workflow_exclude_paths }}"
+          git reset origin/main ${{ inputs.main_sync_workflow_exclude_paths }}
         fi
         if git diff --cached --quiet; then
           echo "No changes staged for commit."

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: ''
   dry_run:
-    description: 'Whether to perform a dry run (skip push and create PR steps)'
+    description: 'True to perform a dry run (dry run git push and skip create PR step)'
     required: false
     default: false
 

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -33,6 +33,7 @@ runs:
   steps:
     - name: Generate PR ID
       id: generate_pr_id
+      shell: bash
       run: echo "pr_id=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Checkout repository
@@ -43,21 +44,26 @@ runs:
         fetch-depth: '0'
 
     - name: Setup git environment
+      shell: bash
       run: |
         git config --global user.name "${{ inputs.username }}"
         git config --global user.email "${{ inputs.useremail }}"
 
     - name: Fetch all
+      shell: bash
       run: git fetch --all
 
     - name: Checkout main branch
+      shell: bash
       run: git checkout main
 
     - name: Create the PR branch
+      shell: bash
       run: git checkout -b sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}
 
     - name: Merge main-apache branch excluding white-listed paths
       id: merge
+      shell: bash
       run: |
         set -x
         git merge --no-commit origin/main-apache || true
@@ -73,6 +79,7 @@ runs:
 
     - name: Check for changes
       id: check_changes
+      shell: bash
       run: |
         set -x
         if git diff --quiet origin/main; then
@@ -85,12 +92,14 @@ runs:
 
     - name: Push changes
       if: steps.check_changes.outputs.is_changed == 'true'
+      shell: bash
       run: |
         set -x
         git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ inputs.dry_run == 'true' && ' --dry-run' || '' }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'
+      shell: bash
       run: |
         set -x
         runUrl="${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -27,6 +27,7 @@ inputs:
     default: false
 
 runs:
+  if: github.repository_owner == 'kiegroup'
   using: 'composite'
   steps:
     - name: Generate PR ID

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -26,6 +26,9 @@ inputs:
     required: false
     default: false
 
+env:
+  GITHUB_TOKEN: ${{ inputs.github_token }}
+
 runs:
   # TODO: uncomment this
   # if: github.repository_owner == 'kiegroup'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -10,9 +10,6 @@ inputs:
     description: 'User email for git'
     required: false
     default: kie-ci0@redhat.com
-  github_token:
-    description: 'GitHub token for authentication'
-    required: true
   main_sync_workflow_exclude_paths:
     description: 'Paths to be excluded during merge'
     required: false
@@ -25,9 +22,6 @@ inputs:
     description: 'Whether to perform a dry run (skip push and create PR steps)'
     required: false
     default: false
-
-env:
-  GITHUB_TOKEN: ${{ inputs.github_token }}
 
 runs:
   # TODO: uncomment this

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -82,8 +82,8 @@ runs:
         fi
 
     - name: Push changes
-      if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'
-      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}
+      if: steps.check_changes.outputs.is_changed == 'true'
+      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}{{ if inputs.dry_run == 'true' }} --dry-run{{ endif }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -87,7 +87,7 @@ runs:
       if: steps.check_changes.outputs.is_changed == 'true'
       run: |
         set -x
-        git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
+        git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'

--- a/.ci/actions/main-sync/action.yml
+++ b/.ci/actions/main-sync/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: Push changes
       if: steps.check_changes.outputs.is_changed == 'true'
-      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}{{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
+      run: git push origin sync-main-pr-${{ steps.generate_pr_id.outputs.pr_id }}${{ if inputs.dry_run == 'true' }} --dry-run {{ endif }}
 
     - name: Create the PR
       if: steps.check_changes.outputs.is_changed == 'true' && inputs.dry_run == 'false'


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-282

**Description:**
Move main-sync CI to kie-ci repository to make it reusable from other midstream repositories


**referenced Pull Requests**: 
- https://github.com/kiegroup/kogito-examples/pull/21
- https://github.com/kiegroup/kogito-runtimes/pull/33
- https://github.com/kiegroup/kogito-apps/pull/21
- https://github.com/kiegroup/drools/pull/46
- https://github.com/kiegroup/kogito-images/pull/34
- https://github.com/kiegroup/kogito-serverless-operator/pull/31
- https://github.com/kiegroup/kie-tools/pull/6